### PR TITLE
Set stage and scene positions based on screen bounds

### DIFF
--- a/src/main/kotlin/org/team2471/frc/pathvisualizer/PathVisualizer.kt
+++ b/src/main/kotlin/org/team2471/frc/pathvisualizer/PathVisualizer.kt
@@ -20,6 +20,7 @@ import javafx.scene.layout.VBox
 import javafx.scene.paint.Color
 import javafx.scene.text.Text
 import javafx.stage.FileChooser
+import javafx.stage.Screen
 import javafx.stage.Stage
 import org.team2471.frc.lib.motion_profiling.*
 import org.team2471.frc.lib.vector.Vector2
@@ -272,7 +273,7 @@ class PathVisualizer : Application() {
         easeCanvas.heightProperty().bind(easeStackPane.heightProperty())
 
         val horizontalSplitPane = SplitPane(verticalSplitPane, buttonsBox)
-        horizontalSplitPane.setDividerPositions(0.7)
+        horizontalSplitPane.setDividerPositions(0.68)
 
 /*
         val menuBar = MenuBar()
@@ -282,8 +283,13 @@ class PathVisualizer : Application() {
         topVBox.children.addAll(menuBar, horizontalSplitPane)
 */
 
-        stage.scene = Scene(horizontalSplitPane, 1600.0, 900.0)
+        val screen = Screen.getPrimary()
+        val bounds = screen.visualBounds
+
+        stage.scene = Scene(horizontalSplitPane, bounds.width, bounds.height)
         stage.sizeToScene()
+        stage.isMaximized = true
+
         repaint()
         stage.show()
 


### PR DESCRIPTION
Some visual elements start off of some screens when width/height is hard-coded.

Sorry for the swarm of PRs, we used quite a few changes to PathVisualizer for Bunnybots and I'm trying to contribute them back upstream without clumping all our unrelated changes in together...