### PR TITLE
Fix delete path button accidentally removing the entire auto

### DIFF
--- a/src/main/kotlin/org/team2471/frc/pathvisualizer/PathVisualizer.kt
+++ b/src/main/kotlin/org/team2471/frc/pathvisualizer/PathVisualizer.kt
@@ -418,8 +418,8 @@ class PathVisualizer : Application() {
 
         val renameAutoButton = Button("Rename Auto")
         val deleteAutoButton = Button("Delete Auto")
-        deletePathButton.setOnAction { _: ActionEvent ->
-            if (selectedAutonomous != null){
+        deleteAutoButton.setOnAction { _: ActionEvent ->
+            if (selectedAutonomous != null) {
                 autonomi.mapAutonomous.remove(selectedAutonomous!!.name, selectedAutonomous)
                 refreshAll()
             }


### PR DESCRIPTION
Prior to this, clicking the delete path button would delete the entire auto due to a typo.