### PR TITLE
Fix field image name

### DIFF
--- a/src/main/kotlin/org/team2471/frc/pathvisualizer/FieldPane.kt
+++ b/src/main/kotlin/org/team2471/frc/pathvisualizer/FieldPane.kt
@@ -14,7 +14,7 @@ import org.team2471.frc.lib.math.Vector2
 import kotlin.math.round
 object FieldPane : StackPane() {
     private val canvas = ResizableCanvas()
-    private val image = Image("assets/2019Field.PNG")
+    private val image = Image("/assets/2019Field.png")
     private val upperLeftOfFieldPixels = Vector2(79.0, 0.0)
     private val lowerRightOfFieldPixels = Vector2(1421.0, 1352.0)
 

--- a/src/main/kotlin/org/team2471/frc/pathvisualizer/FieldPane.kt
+++ b/src/main/kotlin/org/team2471/frc/pathvisualizer/FieldPane.kt
@@ -14,7 +14,7 @@ import org.team2471.frc.lib.math.Vector2
 import kotlin.math.round
 object FieldPane : StackPane() {
     private val canvas = ResizableCanvas()
-    private val image = Image("/assets/2019Field.png")
+    private val image = Image("assets/2019Field.png")
     private val upperLeftOfFieldPixels = Vector2(79.0, 0.0)
     private val lowerRightOfFieldPixels = Vector2(1421.0, 1352.0)
 


### PR DESCRIPTION
Some other programmers on our team were running into this error after cloning and trying to build/run the application:

```
Exception in Application start method
<snip>
Caused by: java.lang.ExceptionInInitializerError
        at org.team2471.frc.pathvisualizer.ControlPanel.<clinit>(ControlPanel.kt:284)
        at org.team2471.frc.pathvisualizer.PathVisualizer.start(PathVisualizer.kt:39)
        at com.sun.javafx.application.LauncherImpl.lambda$launchApplication1$161(LauncherImpl.java:863)
        at com.sun.javafx.application.PlatformImpl.lambda$runAndWait$174(PlatformImpl.java:326)
        at com.sun.javafx.application.PlatformImpl.lambda$null$172(PlatformImpl.java:295)
        at java.security.AccessController.doPrivileged(Native Method)
        at com.sun.javafx.application.PlatformImpl.lambda$runLater$173(PlatformImpl.java:294)
        at com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:95)
        at com.sun.glass.ui.win.WinApplication._runLoop(Native Method)
        at com.sun.glass.ui.win.WinApplication.lambda$null$147(WinApplication.java:177)
        ... 1 more
Caused by: java.lang.IllegalArgumentException: Invalid URL: Invalid URL or resource not found
        at javafx.scene.image.Image.validateUrl(Image.java:1118)
        at javafx.scene.image.Image.<init>(Image.java:620)
        at org.team2471.frc.pathvisualizer.FieldPane.<clinit>(FieldPane.kt:17)
        ... 11 more
Caused by: java.lang.IllegalArgumentException: Invalid URL or resource not found
        at javafx.scene.image.Image.validateUrl(Image.java:1110)
        ... 13 more
```

Changing the image name from "2019Field.PNG" to "2019Field.png" fixed the issue.